### PR TITLE
fix(content): Change the id_token result title

### DIFF
--- a/samples/asgardeo-react-app/src/app.css
+++ b/samples/asgardeo-react-app/src/app.css
@@ -179,3 +179,21 @@ code {
     margin-top: 30px;
     outline: none;
 }
+
+.sub-title {
+    margin-top: 0;
+}
+
+.inline-code-block {
+    border-radius: 6px;
+    -moz-border-radius: 6px;
+    -webkit-border-radius: 6px;
+    padding: 3px 5px;
+    border: 1px solid #cdcdcd;
+    background-color: white;
+    font-family: Monaco, Consolas, "Andale  Mono", "DejaVu Sans Mono", monospace;
+}
+
+.inline-code-block a {
+    text-decoration: none !important;
+}

--- a/samples/asgardeo-react-app/src/pages/home.tsx
+++ b/samples/asgardeo-react-app/src/pages/home.tsx
@@ -94,7 +94,16 @@ export const HomePage: FunctionComponent<{}> = () => {
                         </h1>
                         </div>
                         <div className="content">
-                            <h2>Authentication response derived by the Asgardeo Auth React SDK</h2>
+                            <h2>Authentication Response</h2>
+                            <h4 className="sub-title">
+                                Derived by the&nbsp;
+                                <code className="inline-code-block">
+                                    <a href="https://www.npmjs.com/package/@asgardeo/auth-react/v/latest"
+                                       target="_blank">
+                                        @asgardeo/auth-react
+                                    </a>
+                                </code>&nbsp;SDK
+                            </h4>
                             <div className="json">
                                 <ReactJson
                                     src={authenticateState?.authenticateResponse}

--- a/samples/asgardeo-react-ts-app/src/app.css
+++ b/samples/asgardeo-react-ts-app/src/app.css
@@ -180,3 +180,21 @@ code {
     margin-top: 30px;
     outline: none;
 }
+
+.sub-title {
+    margin-top: 0;
+}
+
+.inline-code-block {
+    border-radius: 6px;
+    -moz-border-radius: 6px;
+    -webkit-border-radius: 6px;
+    padding: 3px 5px;
+    border: 1px solid #cdcdcd;
+    background-color: white;
+    font-family: Monaco, Consolas, "Andale  Mono", "DejaVu Sans Mono", monospace;
+}
+
+.inline-code-block a {
+    text-decoration: none !important;
+}

--- a/samples/asgardeo-react-ts-app/src/pages/home.tsx
+++ b/samples/asgardeo-react-ts-app/src/pages/home.tsx
@@ -50,7 +50,16 @@ const HomePage: FunctionComponent<{}> = () => {
         <DefaultLayout>
             {state.isAuthenticated && (
                 <>
-                    <h2>Authentication response derived by the Asgardeo Auth React SDK</h2>
+                    <h2>Authentication Response</h2>
+                    <h4 className="sub-title">
+                        Derived by the&nbsp;
+                        <code className="inline-code-block">
+                            <a href="https://www.npmjs.com/package/@asgardeo/auth-react/v/latest"
+                               target="_blank">
+                                @asgardeo/auth-react
+                            </a>
+                        </code>&nbsp;SDK
+                    </h4>
                     <div className="json">
                         <ReactJson
                             src={authenticateState?.authenticateResponse}


### PR DESCRIPTION
## Purpose
> Please note the $subject.

- Make "Authentication Response" as the title and made "Derived by the Asgardeo SDK" the subtitle.
- Replace "Asgardeo" with a clickable link to the latest @asgardeo/auth-react package.
- Add style extensions to `<code>` with a CSS class named "inline-code-block"
- Add a sub-title CSS class to remove the top margin of the `<h4>` element

<img width="1039" alt="Sample" src="https://user-images.githubusercontent.com/25561152/110124497-29141a00-7de8-11eb-8342-bf5e84c5d192.png">

