### PR TITLE
Implement a method to sign-in silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ This method returns a promise that resolves with the information about the authe
 #### Example
 
 ```TypeScript
-auth.getBasicUserInfo().then((response) => {
+getBasicUserInfo().then((response) => {
     // console.log(response);
 }).catch((error) => {
     // console.error(error);
@@ -277,7 +277,7 @@ The `sign-in` hook is used to fire a callback function after signing in is succe
 #### Example
 
 ```TypeScript
-auth.signIn();
+signIn();
 ```
 ---
 ### trySignInSilently
@@ -304,7 +304,7 @@ The `sign-in` hook is used to fire a callback function after signing in is succe
 #### Example
 
 ```typescript
-auth.trySignInSilently().then((response)=>{
+trySignInSilently().then((response)=>{
     if(response) {
         // The user is signed in.
         // handle basic user info
@@ -331,7 +331,7 @@ The `sign-out` hook is used to fire a callback function after signing out is suc
 #### Example
 
 ```TypeScript
-auth.signOut();
+signOut();
 ```
 
 ---
@@ -375,7 +375,7 @@ const requestConfig = {
     url: "https://localhost:9443/scim2/me"
 };
 
-return auth.httpRequest(requestConfig)
+return httpRequest(requestConfig)
     .then((response) => {
         // console.log(response);
     })
@@ -408,7 +408,7 @@ This method is used to send multiple http requests at the same time. This works 
 #### Example
 
 ```TypeScript
-auth.httpRequestAll(configs).then((responses) => {
+httpRequestAll(configs).then((responses) => {
     response.forEach((response) => {
         // console.log(response);
     });
@@ -457,7 +457,7 @@ The `custom-grant` hook is used to fire a callback function after a custom grant
       signInRequired: true
     }
 
-    auth.requestCustomGrant(config).then((response)=>{
+    requestCustomGrant(config).then((response)=>{
         console.log(response);
     }).catch((error)=>{
         console.error(error);
@@ -481,7 +481,7 @@ The `end-user-session` hook is used to fire a callback function after end user s
 #### Example
 
 ```TypeScript
-auth.revokeAccessToken();
+revokeAccessToken();
 ```
 
 ---
@@ -512,7 +512,7 @@ This method returns a promise that resolves with an object containing the OIDC e
 #### Example
 
 ```TypeScript
-auth.getOIDCServiceEndpoints().then((endpoints) => {
+getOIDCServiceEndpoints().then((endpoints) => {
     // console.log(endpoints);
 }).error((error) => {
     // console.error(error);
@@ -538,7 +538,7 @@ This method returns a promise that resolves with the decoded payload of the JWT 
 #### Example
 
 ```TypeScript
-auth.getDecodedIDToken().then((idToken) => {
+getDecodedIDToken().then((idToken) => {
     // console.log(idToken);
 }).error((error) => {
     // console.error(error);
@@ -563,7 +563,7 @@ This method returns the id token.
 #### Example
 
 ```TypeScript
-const idToken = await auth.getIDToken();
+const idToken = await getIDToken();
 ```
 ---
 
@@ -584,7 +584,7 @@ This returns a promise that resolves with the access token. The promise resolves
 #### Example
 
 ```TypeScript
-auth.getAccessToken().then((token) => {
+getAccessToken().then((token) => {
     // console.log(token);
 }).error((error) => {
     // console.error(error);
@@ -618,7 +618,7 @@ This method also returns a Promise that resolves with an object containing the a
 #### Example
 
 ```TypeScript
-auth.refreshToken().then((response)=>{
+refreshToken().then((response)=>{
       // console.log(response);
  }).catch((error)=>{
       // console.error(error);
@@ -663,7 +663,7 @@ If you are using TypeScript, you may want to use the `Hooks` enum that consists 
 #### Example
 
 ```TypeScript
-auth.on("sign-in", () => {
+on("sign-in", () => {
     //called after signing in.
 });
 ```
@@ -688,7 +688,7 @@ This method returns a boolean value indicating if the user is authenticated or n
 #### Example
 
 ```TypeScript
-const isAuth = auth.isAuthenticated();
+const isAuth = isAuthenticated();
 ```
 
 ---
@@ -710,7 +710,7 @@ This enables the callback functions attached to the http client. The callback fu
 #### Example
 
 ```TypeScript
-auth.enableHttpHandler();
+enableHttpHandler();
 ```
 
 ---
@@ -732,7 +732,7 @@ This disables the callback functions attached to the http client.
 #### Example
 
 ```TypeScript
-auth.disableHttpHandler();
+disableHttpHandler();
 ```
 
 ### updateConfig
@@ -754,7 +754,7 @@ This method can be used to update the configurations passed into the constructor
 #### Example
 
 ```TypeScript
-auth.updateConfig({
+updateConfig({
     signOutRedirectURL: "https://localhost:5000/sign-out"
 });
 ```
@@ -764,7 +764,7 @@ auth.updateConfig({
 ### getHttpClient
 
 ```TypeScript
-auth.getHttpClient(): `HttpClientInstance`
+getHttpClient(): `HttpClientInstance`
 ```
 
 #### Returns
@@ -778,7 +778,7 @@ This method returns the `HttpClientInstance`. This is the client that is used to
 #### Example
 
 ```TypeScript
-const httpClient = auth.getHttpClient();
+const httpClient = getHttpClient();
 ```
 
 ## Using the `form_post` response mode
@@ -805,7 +805,7 @@ Asgardeo allows the session information including the access token to be stored 
 Of the four methods, storing the session information in the **web worker** is the **safest** method. This is because the web worker cannot be accessed by third-party libraries and data there cannot be stolen through XSS attacks. However, when using a web worker to store the session information, the [`httpRequest`](#httprequest) method has to be used to send http requests. This method will route the request through the web worker and the web worker will attach the access token to the request before sending it to the server.
 
 ```TypeScript
-auth.initialize(config);
+initialize(config);
 ```
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     -   [useAuthContext](#useAuthContext)
     -   [getBasicUserInfo](#getBasicUserInfo)
     -   [signIn](#signIn)
+    -   [trySignInSilently](#trySignInSilently)
     -   [signOut](#signOut)
     -   [httpRequest](#httpRequest)
     -   [httpRequestAll](#httpRequestAll)
@@ -48,6 +49,7 @@
     -   [CustomGrantConfig](#CustomGrantConfig)
     -   [Custom Grant Template Tags](#Custom-Grant-Template-Tags)
     -   [DecodedIDTokenPayload](#DecodedIDTokenPayload)
+    -   [HttpRequestConfig](#HttpRequestConfig)
 -   [Develop](#develop)
     -   [Prerequisites](#prerequisites)
     -   [Installing Dependencies](#installing-dependencies)
@@ -64,16 +66,6 @@ Install the library from the npm registry.
 
 ```
 npm install --save @asgardeo/auth-react
-```
-
-Or simply load the SDK by importing the script into the header of your HTML file.
-
-```html
-<script src="https://unpkg.com/@asgardeo/auth-react@0.1.26/dist/asgardeo-react.production.min.js.js"></script>
-
-<script>
-    var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
-</script>
 ```
 
 ## Getting Started
@@ -286,6 +278,40 @@ The `sign-in` hook is used to fire a callback function after signing in is succe
 
 ```TypeScript
 auth.signIn();
+```
+---
+### trySignInSilently
+
+```typescript
+trySignInSilently();
+```
+
+#### Description
+
+This method attempts to sign a user in silently by sending an authorization request with the `prompt` query parameter set to `none`.
+This will be useful when you want to sign a user in automatically while avoiding the browser redirects.
+
+This uses an iFrame to check if there is an active user session in the identity server by sending an authorization request. If the request returns an authorization code, then the token request is dispatched and the returned token is stored effectively signing the user in.
+
+To dispatch a token request, the `[signIn()](#signIn)` or this `trySignInSilently()` method should be called by the page/component rendered by the redirect URL.
+
+This returns a promise that resolves with a `[BasicUserInfo](#BasicUserInfo)` object following a successful sign in. If the user is not signed into the identity server, then the promise resolves with the boolean value of `false`.
+
+The `sign-in` hook is used to fire a callback function after signing in is successful. Check the [on()](#on) section for more information.
+
+> :warning: ***Since this method uses an iFrame, this method will not work if third-party cookies are blocked in the browser.***
+
+#### Example
+
+```typescript
+auth.trySignInSilently().then((response)=>{
+    if(response) {
+        // The user is signed in.
+        // handle basic user info
+    }
+
+    // The user is not signed in.
+});
 ```
 
 ---
@@ -807,7 +833,7 @@ This table shows the extended attributes provided by the `Config` interface.
 
 #### The AuthClientConfig Interface
 
-| Attribute | Required/Optional | Type | Default Value | Description | 
+| Attribute | Required/Optional | Type | Default Value | Description |
 | --------- | ----------------- | ---- | ------------- | ----------- |
 | `signInRedirectURL`          | Required          | `string`        | ""                                                                      | The URL to redirect to after the user authorizes the client app. eg: `https//localhost:5000/sign-in` |
 | `signOutRedirectURL`         | Optional          | `string`        | The `signInRedirectURL` URL will be used if this value is not provided. | The URL to redirect to after the user                                                                | signs out. eg: `https://localhost:5000/dashboard`                                                                                                           |
@@ -893,6 +919,12 @@ Session information can be attached to the body of a custom-grant request using 
 | email              | `string`               | The email address.                             |
 | preferred_username | `string`               | The preferred username.                        |
 | tenant_domain      | `string`               | The tenant domain to which the user belongs.   |
+
+### HTTPRequestConfig
+This extends the `AxiosRequestConfig` by providing an additional attribute that is used to specify if the access token should be attached to the request or not.
+|Attribute | Type | Description|
+|--|--|--|
+|attachToken| `boolean`| Specifies if the access token should be attached to the header of the request.|
 
 ## Develop
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -34,7 +34,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^0.1.8"
+        "@asgardeo/auth-spa": "^0.1.10"
     },
     "devDependencies": {
         "@babel/cli": "^7.10.5",

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -336,6 +336,45 @@ class AuthAPI {
 
         return this._client.on(hook, callback);
     }
+
+    /**
+     * This method allows you to sign in silently.
+     * First, this method sends a prompt none request to see if there is an active user session in the identity server.
+     * If there is one, then it requests the access token and stores it. Else, it returns false.
+     *
+     * @return {Promise<BasicUserInfo | boolean>} - A Promise that resolves with the user information after signing in
+     * or with `false` if the user is not signed in.
+     *
+     * @example
+     *```
+     * client.trySignInSilently()
+     *```
+     */
+    public async trySignInSilently(
+        state: AuthStateInterface,
+        dispatch: (state: AuthStateInterface) => void
+    ): Promise<BasicUserInfo | boolean | undefined> {
+        return this._client.trySignInSilently().then((response: BasicUserInfo | boolean) => {
+            if (response) {
+                const basicUserInfo = response as BasicUserInfo;
+                const stateToUpdate = {
+                    allowedScopes: basicUserInfo.allowedScopes,
+                    displayName: basicUserInfo.displayName,
+                    email: basicUserInfo.email,
+                    isAuthenticated: true,
+                    username: basicUserInfo.username
+                };
+
+                this.updateState(stateToUpdate);
+
+                dispatch({ ...state, ...stateToUpdate });
+
+                return response;
+            }
+
+            return false;
+        });
+    }
 }
 
 AuthAPI.DEFAULT_STATE = {

--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -92,6 +92,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
 
         return AuthClient.on(hook, callback);
     };
+    const trySignInSilently = () => AuthClient.trySignInSilently(state, dispatch);
 
     useEffect(() => {
         if (state.isAuthenticated) {
@@ -126,6 +127,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
                 signIn,
                 signOut,
                 state,
+                trySignInSilently,
                 updateConfig
             } }
         >

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -45,7 +45,7 @@ export interface AuthContextInterface {
     httpRequestAll(configs: HttpRequestConfig[]): Promise<HttpResponse<any>[]>;
     requestCustomGrant(
         config: CustomGrantConfig,
-        callback?: (response: BasicUserInfo | HttpResponse<any>) => void,
+        callback?: (response: BasicUserInfo | HttpResponse<any>) => void
     ): void;
     revokeAccessToken(): Promise<boolean>;
     getOIDCServiceEndpoints(): Promise<OIDCEndpoints>;
@@ -58,6 +58,7 @@ export interface AuthContextInterface {
     enableHttpHandler(): Promise<boolean>;
     disableHttpHandler(): Promise<boolean>;
     updateConfig(config: Partial<AuthClientConfig<Config>>): Promise<void>;
+    trySignInSilently: () => Promise<boolean | BasicUserInfo>;
     on(hook: Hooks.CustomGrant, callback: (response?: any) => void, id: string): void;
     on(
         hook:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@asgardeo/auth-js@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-0.2.8.tgz#f3d891ccee516e929e9bf1c77546fc21bd70ffcb"
-  integrity sha512-0HRFUhBK0NEsquoVDsDV0DPPHEhJGdP8zxPtv9W0NvPUJMR7TfyZn8euqp+mYdeMRtEdh56qaneh0we73vn2uw==
+"@asgardeo/auth-js@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-0.2.9.tgz#4e7bd53c1035fa8029f4ce5fc21f8b0050189822"
+  integrity sha512-xGwUflJWZRuS+wQZn5/lysLGBmm9KeLF94sKbvSQsz2NIvDEQFnOKe39GSUW665d2BewQFURUcsvSxLZvmIaKQ==
   dependencies:
     base64url "^3.0.1"
     fast-sha256 "^1.3.0"
     jose "^3.1.2"
     randombytes "^2.1.0"
 
-"@asgardeo/auth-spa@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.1.8.tgz#99836c9cca8f86f5ae518bbccdcea64c01bf2176"
-  integrity sha512-oxZIXQGFyEOC7z8X+Sajfwmc1O0TRe8PwKecqJ1WgWI+w7N5q3Dnx//If6oOeBpoWbOboQUWE8+9xlROWEAjWA==
+"@asgardeo/auth-spa@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.1.10.tgz#29c2017c8416a0860d5012ef1a533b042f468a2b"
+  integrity sha512-EFM4ohrTxuD3HrQG3ipV0F4vqIkYmfL2i2HM6nYW9vc4KXZ94MAFebPR1Q9Zpvt2Z2tomfN9ZgU4yeugaskZ7Q==
   dependencies:
-    "@asgardeo/auth-js" "^0.2.8"
+    "@asgardeo/auth-js" "^0.2.9"
     "@babel/runtime-corejs3" "^7.11.2"
     await-semaphore "^0.1.3"
     axios "^0.21.0"


### PR DESCRIPTION
This PR introduces a method called `trySignInSilently()` that allows signing in without explicit browser redirects.

This method attempts to sign a user in silently by sending an authorization request with the prompt query parameter set to none.
This will be useful when you want to sign a user in automatically while avoiding the browser redirects.

This uses an iFrame to check if there is an active user session in the identity server by sending an authorization request. If the request returns an authorization code, then the token request is dispatched and the returned token is stored effectively signing the user in.

To dispatch a token request, the `signIn()` or this trySignInSilently() method should be called by the page/component rendered by the redirect URL.

This returns a promise that resolves with a [BasicUserInfo](#BasicUserInfo) object following a successful sign-in. If the user is not signed into the identity server, then the promise resolves with the boolean value of false.

The sign-in hook is used to fire a callback function after signing in is successful.

⚠️ Since this method uses an iFrame, this method will not work if third-party cookies are blocked in the browser.

Related PR: https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/42


Resolves https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/35