### PR TITLE
Introduce a prop method to pass authorization code and session state into the AuthProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ The provider takes a prop called `config` that accepts a config object of type [
 
 In addition, the `fallback` prop is used to specify a fallback component that will be rendered when the user is not authenticated.
 
+The `AuthProvider` also automatically requests for the access token should the URL contain the `code` query parameter.
+
+If the response mode is set to `form_post`, then you will have your own ways of retrieving the authorization code and session state from your backend. In that case, you can use the `getAuthParams()` prop method to pass an async callback function that would return the `authorizationCode` and `sessionState` in a Promise. This way, the `AuthProvider` will use the authorization code returned by this method to automatically request for an access token.
+
 #### Example
 
 ```TypeScript

--- a/lib/package.json
+++ b/lib/package.json
@@ -35,7 +35,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^0.2.3"
+        "@asgardeo/auth-spa": "^0.2.4"
     },
     "devDependencies": {
         "@babel/cli": "^7.10.5",

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -100,3 +100,11 @@ export interface SecureRouteInterface {
     callback: () => void;
     component: any;
 }
+
+/**
+ * The model of the object returned by the `getAuthParams` prop method of the `AuthProvider`.
+ */
+export interface AuthParams {
+    authorizationCode?: string;
+    sessionState?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
     jose "^3.1.2"
     randombytes "^2.1.0"
 
-"@asgardeo/auth-spa@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.3.tgz#b7936b3b71cb05e5b58da80e4bb96c88f3da70e9"
-  integrity sha512-vK+hruL+NYQqqnNA0bJiqBQJgBNHcAS54XoEvS3QeY/ZP9srMdVg5hXDaDpCKoodlPMW1meVcMr/Yvl1wDBFJg==
+"@asgardeo/auth-spa@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.4.tgz#959e7377d271d3edcd5f3803daab0b4ac6a0e587"
+  integrity sha512-xxnN+JruYZtUixIwg+RjUNjs2D9KgOe12Nb0FMuSN5xk/jBB+B7PhdPkkyXAWGp57kEyyOktRLoPKNkKNKZ6Fw==
   dependencies:
     "@asgardeo/auth-js" "^0.2.12"
     "@babel/runtime-corejs3" "^7.11.2"


### PR DESCRIPTION
## Purpose
>  This PR introduces a prop method to pass the authorization code and session state into the `AuthProvider`. This can be used if the response mode is set to `form_post`. The method is named `getAuthParams` and is expected return a Promise that resolves with an object that consists of `authorizationCode` and `sessionState` attributes. 
```Typescript
<AuthProvider config={ config } getAuthParams={()=>fetchAuthorizationCode()}>
</AuthProvider>
```