### PR TITLE
Adding react ^17 version support in  peerDependencies

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -68,8 +68,8 @@
     },
     "peerDependencies": {
         "@babel/runtime-corejs3": "^7.11.2",
-        "react": "^16.14.0",
-        "react-dom": "16.14.0",
+        "react": "^16.14.0 || ^17.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0",
         "react-router-dom": "^5.2.0"
     }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -68,8 +68,8 @@
     },
     "peerDependencies": {
         "@babel/runtime-corejs3": "^7.11.2",
-        "react": "^16.14.0 || ^17.0.0",
-        "react-dom": "^16.14.0 || ^17.0.0",
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
         "react-router-dom": "^5.2.0"
     }
 }


### PR DESCRIPTION
## Purpose

- Adding react 17.x.x versions in peerDependencies
- adding missing `^`
- Allowing apps with react 17 to install dependency without having 2 react versions I:e [MUI](https://github.com/mui-org/material-ui/blob/v4.x/packages/material-ui/package.json#L43-L44)
- React 17 has almost [no breaking changes](https://reactjs.org/blog/2020/10/20/react-v17.html#other-breaking-changes)