### PR TITLE
Fix repeated authorization requests being sent when the page is refreshed issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 -   [Storage](#storage)
 -   [Models](#models)
     -   [AuthStateInterface](#authstateinterface)
-    -   [AuthClientConfig\<Config>](#authclientconfigconfig)
+    -   [AuthReactConfig>](#authreactconfig)
     -   [BasicUserInfo](#basicuserinfo)
     -   [SignInConfig](#signinconfig)
     -   [OIDCEndpoints](#oidcendpoints)
@@ -854,18 +854,7 @@ initialize(config);
 | `isLoading`       | `boolean` | Specifies if the authentication requests are loading. |
 | `username`        | `string`  | The username of the user.                            |
 
-### AuthClientConfig\<Config>
-
-The `AuthClientConfig<Config>` interface extends the `AuthClientConfig<T>` interface provided by the `Asgardeo JavaScript Auth SDK` with the `Config` interface. This table lists the attributes that the `AuthClientConfig<T>` interface takes.
-
-This table shows the extended attributes provided by the `Config` interface.
-| Attribute | Required/Optional | Type | Default Value | Description |
-|:----|:----|:----|:----|:----|
-| [`storage`](#storage) | Optional | `"sessionStorage"`, `"webWorker"`, `"localStorage"` | `"sessionStorage"` | The storage medium where the session information such as the access token should be stored.| |
-| `resourceServerURLs` |Required if the `storage` is set to `webWorker` | `string[]` | `[]` | The URLs of the API endpoints. This is needed only if the storage method is set to `webWorker`. When API calls are made through the [`httpRequest`](#httprequest) or the [`httpRequestAll`](#httprequestall) method, only the calls to the endpoints specified in the `baseURL` attribute will be allowed. Everything else will be denied. | |
-|`requestTimeout` | Optional | `number`| 60000 (seconds) | Specifies in seconds how long a request to the web worker should wait before being timed out. |
-
-#### The AuthClientConfig Interface
+### AuthReactConfig
 
 | Attribute | Required/Optional | Type | Default Value | Description |
 | --------- | ----------------- | ---- | ------------- | ----------- |
@@ -885,6 +874,10 @@ This table shows the extended attributes provided by the `Config` interface.
 | `validateIDToken`            | Optional          | `boolean`       | `true`                                                                  | Allows you to enable/disable JWT ID token validation after obtaining the ID token.                   |
 | `clockTolerance`             | Optional          | `number`        | `60`                                                                    | Allows you to configure the leeway when validating the id_token.                                     |
 | `skipRedirectCallback`       | Optional          | `boolean`        | `false`                                                                    | Stop listening to Auth param changes i.e `code` & `session_state` to trigger auto login.        |
+| [`storage`](#storage) | Optional | `"sessionStorage"`, `"webWorker"`, `"localStorage"` | `"sessionStorage"` | The storage medium where the session information such as the access token should be stored.| |
+| `resourceServerURLs` |Required if the `storage` is set to `webWorker` | `string[]` | `[]` | The URLs of the API endpoints. This is needed only if the storage method is set to `webWorker`. When API calls are made through the [`httpRequest`](#httprequest) or the [`httpRequestAll`](#httprequestall) method, only the calls to the endpoints specified in the `baseURL` attribute will be allowed. Everything else will be denied. | |
+|`requestTimeout` | Optional | `number`| 60000 (seconds) | Specifies in seconds how long a request to the web worker should wait before being timed out. |
+| `disableTrySignInSilently` | Optional | `boolean` | `false` | Specifies if the SDK should try to sign in silently on mount.|
 
 ### BasicUserInfo
 
@@ -903,6 +896,7 @@ This table shows the extended attributes provided by the `Config` interface.
 | ------------- | ----------------- | --------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `fidp`        | Optional          | `string`              | ""            | The `fidp` parameter that can be used to redirect a user directly to an IdP's sign-in page.                                                                            |
 | `forceInit`   | Optional          | `boolean`             | `false`       | Forces obtaining the OIDC endpoints from the `.well-known` endpoint. A request to this endpoint is not sent if a request has already been sent. This forces a request. |
+| `callOnlyOnRedirect` | Optional | `boolean` | `false` | Specifies if the SDK should only call the `signIn` method when the user is redirected back to the client app. |
 | key: `string` | Optional          | `string` \| `boolean` | ""            | Any key-value pair to be appended as path parameters to the authorization URL.                                                                                         |
 
 ### OIDCEndpoints

--- a/lib/package.json
+++ b/lib/package.json
@@ -35,7 +35,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^0.2.5"
+        "@asgardeo/auth-spa": "^0.2.7"
     },
     "devDependencies": {
         "@babel/cli": "^7.10.5",

--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -44,7 +44,7 @@ import { AuthContextInterface, AuthReactConfig, AuthStateInterface } from "./mod
  * Default `AuthClientConfig<AuthReactConfig>` config.
  */
 const defaultConfig: Partial<AuthClientConfig<AuthReactConfig>> = {
-    enableTrySignInSilently: true
+    disableTrySignInSilently: false
 };
 
 const AuthClient = new AuthAPI();
@@ -55,7 +55,7 @@ const AuthClient = new AuthAPI();
 const AuthContext = createContext<AuthContextInterface>(null);
 
 interface AuthProviderPropsInterface {
-    config: AuthClientConfig<AuthReactConfig>;
+    config: AuthReactConfig;
     fallback?: ReactNode;
     getAuthParams?: () => Promise<AuthParams>;
     onSignOut?: () => void;
@@ -70,7 +70,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
     const { children, config: passedConfig, fallback, getAuthParams, onSignOut } = props;
 
     const config = useMemo(
-        (): AuthClientConfig<AuthReactConfig> => ({ ...defaultConfig, ...passedConfig }), [ passedConfig ]
+        (): AuthReactConfig => ({ ...defaultConfig, ...passedConfig }), [ passedConfig ]
     );
 
     const signIn = async(
@@ -166,7 +166,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
                 return;
             }
 
-            if (!config.enableTrySignInSilently || isSignedOut) {
+            if (config.disableTrySignInSilently || isSignedOut) {
                 dispatch({ ...state, isLoading: false });
 
                 return;

--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -32,12 +32,20 @@ import React, {
     createContext,
     useContext,
     useEffect,
+    useMemo,
     useState,
     ReactNode
 } from "react";
 import { AuthParams } from ".";
 import AuthAPI from "./api";
 import { AuthContextInterface, AuthReactConfig, AuthStateInterface } from "./models";
+
+/**
+ * Default `AuthClientConfig<AuthReactConfig>` config.
+ */
+const defaultConfig: Partial<AuthClientConfig<AuthReactConfig>> = {
+    enableTrySignInSilently: true
+};
 
 const AuthClient = new AuthAPI();
 
@@ -50,6 +58,7 @@ interface AuthProviderPropsInterface {
     config: AuthClientConfig<AuthReactConfig>;
     fallback?: ReactNode;
     getAuthParams?: () => Promise<AuthParams>;
+    onSignOut?: () => void;
 }
 
 const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterface>> = (
@@ -58,7 +67,11 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
     const [ state, dispatch ] = useState<AuthStateInterface>(AuthClient.getState());
     const [ initialized, setInitialized ] = useState(false);
 
-    const { children, config, fallback, getAuthParams } = props;
+    const { children, config: passedConfig, fallback, getAuthParams, onSignOut } = props;
+
+    const config = useMemo(
+        (): AuthClientConfig<AuthReactConfig> => ({ ...defaultConfig, ...passedConfig }), [ passedConfig ]
+    );
 
     const signIn = async(
         config?: SignInConfig,
@@ -112,13 +125,21 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
      * Try signing in when the component is mounted.
      */
     useEffect(() => {
-
-        // User is already authenticated. Skip...
-        if (state.isAuthenticated) {
-            return;
-        }
-
         (async () => {
+            let isSignedOut: boolean = false;
+            await on(Hooks.SignOut, () => {
+                isSignedOut = true;
+
+                if (onSignOut) {
+                    onSignOut();
+                }
+            });
+
+            // User is already authenticated. Skip...
+            if (state.isAuthenticated) {
+                return;
+            }
+
             // If `skipRedirectCallback` is not true, check if the URL has `code` and `session_state` params.
             // If so, initiate the sign in.
             if (!config.skipRedirectCallback) {
@@ -127,19 +148,27 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
                     authParams = await getAuthParams();
                 }
 
-                await signIn({ callOnlyOnRedirect: true }, authParams?.authorizationCode, authParams?.sessionState)
-                    .then(() => {
-                        // TODO: Add logs when a logger is available.
-                        // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
-                    })
-                    .catch((error) => {
-                        // TODO: Add logs when a logger is available.
-                        // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
-                        throw error;
-                    });
+                if (SPAUtils.hasAuthSearchParamsInURL() || authParams?.authorizationCode) {
+                    await signIn({ callOnlyOnRedirect: true }, authParams?.authorizationCode, authParams?.sessionState)
+                        .then(() => {
+                            // TODO: Add logs when a logger is available.
+                            // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
+                        })
+                        .catch((error) => {
+                            // TODO: Add logs when a logger is available.
+                            // Tracked here https://github.com/asgardeo/asgardeo-auth-js-sdk/issues/151.
+                            throw error;
+                        });
+                }
             }
 
             if (AuthClient.getState().isAuthenticated) {
+                return;
+            }
+
+            if (!config.enableTrySignInSilently || isSignedOut) {
+                dispatch({ ...state, isLoading: false });
+
                 return;
             }
 
@@ -157,7 +186,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
                 });
         })();
 
-    }, []);
+    }, [ config ]);
 
     /**
      * Render state and special case actions

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -38,6 +38,11 @@ export interface AuthReactConfig extends SPAConfig {
      * token exchange. This option could be used to override that behaviour.
      */
     skipRedirectCallback?: boolean;
+    /**
+     * The `AuthProvider`, by default, looks for an active session in the server and updates the session information
+     * with the latest session information from the server. This option could be used to disable that behaviour.
+     */
+    enableTrySignInSilently?: boolean;
 }
 
 export interface AuthStateInterface {

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -31,7 +31,7 @@ import {
     SPAConfig
 } from "@asgardeo/auth-spa";
 
-export interface AuthReactConfig extends SPAConfig {
+export interface ReactConfig extends SPAConfig {
     /**
      * The SDK's `AuthProvider` by default is listening to the URL changes to see
      * if `code` & `session_state` search params are available so that it could perform
@@ -42,9 +42,10 @@ export interface AuthReactConfig extends SPAConfig {
      * The `AuthProvider`, by default, looks for an active session in the server and updates the session information
      * with the latest session information from the server. This option could be used to disable that behaviour.
      */
-    enableTrySignInSilently?: boolean;
+    disableTrySignInSilently?: boolean;
 }
 
+export type AuthReactConfig = AuthClientConfig<ReactConfig>;
 export interface AuthStateInterface {
     allowedScopes: string;
     displayName?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
     jose "^3.1.2"
     randombytes "^2.1.0"
 
-"@asgardeo/auth-spa@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.5.tgz#15c95f6232bac267638058572aff512b467726b3"
-  integrity sha512-EvFpQiLN2k45gxKUVpj3mKK6LMeECJqgjFWPy666qjPyDnzR92JBt0oKdMpHoJjG6aN0JnWL2Ou8glJVIZ2+Tw==
+"@asgardeo/auth-spa@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.7.tgz#d9a2f8fceea4d9e84a76874d6ca38f7f68deae7f"
+  integrity sha512-DZfrnu+14PlKpHSR8FI3ZN4N1z6Wd/6SOloGnN9O0burEMlnrXIvdbnPzHP/3ZN8dILl6TKRJe6U+4DMJeJ+iQ==
   dependencies:
     "@asgardeo/auth-js" "^0.2.14"
     "@babel/runtime-corejs3" "^7.11.2"


### PR DESCRIPTION
## Purpose
> This PR addresses the following:
1. Fixes the issue of repeated authorization requests being sent when the page is refreshed. This is addressed by ensuring the `signIn` method is automatically called only when there is an authorization code.
2. Allows `trySignInSilently` to be disabled. A config parameter called `disableTrySignInSilently` has been introduced, which can be set to `false` to prevent automatic logins.
3. Prevents automatic sign-in attempt after signing out. 