### PR TITLE
Add `sub` attribute to Authenticated state

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,14 +878,15 @@ initialize(config);
 
 ### AuthStateInterface
 
-| Attribute         | Type      | Description                                          |
-| :---------------- | :-------- | :--------------------------------------------------- |
-| `allowedScopes`   | `string`  | The scopes that are allowed for the user.            |
-| `displayName`     | `string`  | The display name of the user.                        |
-| `email`           | `string`  | The email address of the user.                       |
-| `isAuthenticated` | `boolean` | Specifies if the user is authenticated or not.        |
-| `isLoading`       | `boolean` | Specifies if the authentication requests are loading. |
-| `username`        | `string`  | The username of the user.                            |
+| Attribute         | Type      | Description                                                               |
+| :---------------- | :-------- | :------------------------------------------------------------------------ |
+| `allowedScopes`   | `string`  | The scopes that are allowed for the user.                                 |
+| `displayName`     | `string`  | The display name of the user.                                             |
+| `email`           | `string`  | The email address of the user.                                            |
+| `isAuthenticated` | `boolean` | Specifies if the user is authenticated or not.                             |
+| `isLoading`       | `boolean` | Specifies if the authentication requests are loading.                      |
+| `username`        | `string`  | The username of the user.                                                 |
+| `sub`             | `string`  | The `uid` corresponding to the user to whom the ID token belongs to.      |
 
 ### AuthReactConfig
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -36,7 +36,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^0.2.12"
+        "@asgardeo/auth-spa": "^0.2.14"
     },
     "devDependencies": {
         "@babel/cli": "^7.10.5",

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -96,6 +96,7 @@ class AuthAPI {
                         isAuthenticated: true,
                         isLoading: false,
                         isSigningOut: false,
+                        sub: response.sub,
                         username: response.username
                     };
 
@@ -405,7 +406,8 @@ class AuthAPI {
                         isAuthenticated: true,
                         isLoading: false,
                         username: basicUserInfo.username,
-                        isSigningOut: false
+                        isSigningOut: false,
+                        sub: basicUserInfo.sub
                     };
 
                     this.updateState(stateToUpdate);
@@ -427,7 +429,8 @@ AuthAPI.DEFAULT_STATE = {
     email: "",
     isAuthenticated: false,
     isLoading: true,
-    username: ""
+    username: "",
+    sub: ""
 };
 
 export default AuthAPI;

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -47,15 +47,38 @@ export interface ReactConfig {
 
 export type AuthReactConfig = AuthSPAClientConfig & ReactConfig;
 
+/**
+ * Interface for the Authenticated state of the user which is exposed
+ * via `state` object from `useAuthContext` hook.
+ */
 export interface AuthStateInterface {
+    /**
+     * The scopes that are allowed for the user.
+     */
     allowedScopes: string;
+    /**
+     * The display name of the user.
+     */
     displayName?: string;
+    /**
+     * The email address of the user.
+     */
     email?: string;
+    /**
+     * Specifies if the user is authenticated or not.
+     */
     isAuthenticated: boolean;
     /**
      * Are the Auth requests loading.
      */
     isLoading: boolean;
+    /**
+     * The uid corresponding to the user who the ID token belonged to.
+     */
+    sub?: string;
+    /**
+     * The username of the user.
+     */
     username?: string;
 }
 

--- a/lib/src/reducer.ts
+++ b/lib/src/reducer.ts
@@ -28,7 +28,8 @@ const authenticateInitialState: AuthStateInterface = {
     email: "",
     isAuthenticated: false,
     isLoading: true,
-    username: ""
+    username: "",
+    sub: ""
 };
 
 /**
@@ -48,7 +49,8 @@ const authenticateReducer = (state, action) => {
                 email: action.payload.email,
                 isAuthenticated: true,
                 isLoading: false,
-                username: action.payload.username
+                username: action.payload.username,
+                sub: action.payload.sub
             };
         case AuthContextReducerActionTypes.SET_SIGN_OUT:
             return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@asgardeo/auth-js@^0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-0.2.16.tgz#58206e7e3e0210c1bbe6db0c827a882d197e40a5"
-  integrity sha512-Zwdbj1lRUk/PynEatLxyanEVh6/vkp9H0dhOi3aNAeztyBAhcB28KDV89Z2PrUEIVtCwwk/rxTh8NJDAnz1GzA==
+"@asgardeo/auth-js@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-0.2.18.tgz#5c45ca5ff67eb6b298d4d325ab96cecc601284da"
+  integrity sha512-qJtOttRXdJ+uiDKfUuzSOU5Ty3/VfCVXSmcCq+8WVyYSr4o7twCBKK6ZwWW0ixqJ4xCczJrGa5ozzeVL+gN20A==
   dependencies:
     base64url "^3.0.1"
     fast-sha256 "^1.3.0"
     jose "^3.1.2"
     randombytes "^2.1.0"
 
-"@asgardeo/auth-spa@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.12.tgz#1bf9d15b642daad57d761c3405b2ad690a06db85"
-  integrity sha512-zoyPj66LuIg7XlpdzGSNCJa97ibzqYcnxG5AxFQRefTLZ2pyupdirNIBxlMBRb+0BJc7jqIseNJXdnzzT0FV2w==
+"@asgardeo/auth-spa@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.2.14.tgz#c73d94c63398bdc587204d8bb83d827d90db38c4"
+  integrity sha512-sHUHve7tQ5DJPJmV4ZURwCSAUnzE5/CdHya02CnL4LYTSDdGyZKYRkeEruetbfRFdSB8cVG/k5mbLK1TXP9YvQ==
   dependencies:
-    "@asgardeo/auth-js" "^0.2.16"
+    "@asgardeo/auth-js" "^0.2.18"
     "@babel/runtime-corejs3" "^7.11.2"
     await-semaphore "^0.1.3"
     axios "^0.21.0"


### PR DESCRIPTION
## Purpose
Bring in changes done in https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163 & https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/64 to enable returning the `sub` from the `id_token` as a high level item via the Authenticated State.

## Goals
Fixes https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/64

## Approach
Refer https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163 & https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/64

<img width="935" alt="Screen Shot 2021-10-28 at 11 03 37 PM" src="https://user-images.githubusercontent.com/25959096/139308995-d746c984-2d00-4c54-ad2e-65f2232678d9.png">

## User stories
None

## Release note
None

## Documentation
None

## Training
None

## Certification
None

## Marketing
None

## Automation tests
None

## Security checks
None

## Samples
None

## Related PRs
None

## Migrations (if applicable)
None

## Test environment
None
 
## Learning
None