### PR TITLE
Revert "Bump asgardeo-auth-spa-sdk version to 0.4.2"

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -36,7 +36,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^0.4.2"
+        "@asgardeo/auth-spa": "^0.4.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-2.0.12.tgz#8a27e2664d76e912e5027b48f861c7133720e1b4"
   integrity sha512-xmgYjtgfd4SpPd3j6OfyyqSoUrCThH8FrIzm8PM4dl9iEJfaAjRJs26zeVoUByAa9DjzBC8z+8+k4CPMStEdEA==
 
-"@asgardeo/auth-spa@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.4.2.tgz#90e5222e6c8ebaf7ee25dd23921583e1680dc1b5"
-  integrity sha512-a8M8o9ToRppsuNChBf08DkHL9QdxaWRcwV8mBDlc0laVwbutIc/Gi/ZcfFz/hwho+2zyREtLF3te3duM8fNfww==
+"@asgardeo/auth-spa@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-0.4.1.tgz#1998b68c29ed2bfa5ef0dad6f046553aa576c253"
+  integrity sha512-OlgY93NRVV/vkmNiQapwOD8BaYMYGDVJVIGvIfzjFtDpPf+XPa4p+A/q3avqd5o6P2noIAG7l+ilCUgRMn9rhg==
   dependencies:
     "@asgardeo/auth-js" "^2.0.12"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
Reverts asgardeo/asgardeo-auth-react-sdk#112

The changes in this PR are now not necessary.