### PR TITLE
Include a comment explaining about the side effects of registering a sign-out hook in the AuthProvider component.

### DIFF
--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -148,6 +148,8 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
     useEffect(() => {
         (async () => {
             let isSignedOut: boolean = false;
+            // If the component was mounted after the user was redirected to the application upon a successful logout,
+            // then the locally stored user session will be cleared as a side effect of registering this sign-out hook.
             await on(Hooks.SignOut, () => {
                 isSignedOut = true;
 


### PR DESCRIPTION
## Purpose
> Because of the recent changes in Auth SPA SDK, clearing the user session after a successful logout is done when the user is redirected back to the `signOutRedirectURL` . This is done by registering a sign-out hook using the `on()` method when `signOutRedirectURL` is loaded. Since the `AuthProvider` component already registers a sign-out hook, the clearing of the user session happens as a side effect of registering that hook. Including a comment explaining this will mitigate possible confusion in the future.

