### PR TITLE
[React 18] Add ref to handle `Strict Mode` re-renders in Protected Route

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -22,6 +22,7 @@
         "fix-lint": "eslint --ext .js,.ts . --fix",
         "build": "rimraf dist && npm run type-check && webpack -p --env.NODE_ENV=production",
         "build:dev": "rimraf dist && npm run type-check && webpack -p --env.NODE_ENV=development",
+        "build:watch": "npm run build:dev -- --watch",
         "type-check": "tsc --emitDeclarationOnly",
         "type-check:watch": "npm run type-check -- --watch"
     },


### PR DESCRIPTION
## Purpose
$subject 

## Goals
Address https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/125

## Related PRs
- https://github.com/asgardeo/asgardeo-auth-react-sdk/pull/128
- https://github.com/asgardeo/asgardeo-auth-react-sdk/pull/126

## Approach

Add a ref to make sure the effect run only once as suggested in https://github.com/reactwg/react-18/discussions/18#discussioncomment-795623
