### PR TITLE
Fix state.isAuthenticated update on page reload

### DIFF
--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -142,6 +142,7 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
         }
         (async () => {
             setInitialized(await AuthClient.init(config));
+            checkIsAuthenticated();
         })();
 
     }, [ config ]);
@@ -242,6 +243,18 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
         })();
 
     }, [ config ]);
+
+    /**
+     * Check if the user is authenticated and update the state.isAuthenticated value.
+     */
+    const checkIsAuthenticated = async () => {
+        const isAuthenticatedState = await AuthClient.isAuthenticated();        
+
+        if (isAuthenticatedState) {
+            AuthClient.updateState({ ...state, isAuthenticated: isAuthenticatedState, isLoading: false });
+            dispatch({ ...state, isAuthenticated: isAuthenticatedState, isLoading: false });
+        }
+    };
 
     /**
      * Render state and special case actions


### PR DESCRIPTION
## Purpose
This will fix the issue where `state.isAuthenticated` value is set to `false` when the page is refreshed even when the user is already authenticated.

## Related Issue
- Resolves https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/143
