### PR TITLE
Restrict json-viewer version to 2.14.0

### DIFF
--- a/samples/asgardeo-react-app/package.json
+++ b/samples/asgardeo-react-app/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@asgardeo/auth-react": "^2.0.4",
         "@babel/runtime-corejs3": "^7.20.6",
-        "@textea/json-viewer": "^2.14.0",
+        "@textea/json-viewer": "2.14.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The latest version of json-viewer is throwing errors when starting the react sample application [1]. This PR is to restrict the jsoon-viewer version used in the sample app to 2.14.0 until the issue is fixed.

[1] https://github.com/TexteaInc/json-viewer/issues/308