### PR TITLE
Add specific error pages for ID token validation failures

### DIFF
--- a/samples/asgardeo-react-app/src/app.css
+++ b/samples/asgardeo-react-app/src/app.css
@@ -130,6 +130,23 @@ code {
     margin-right: 0;
 }
 
+.error-page_h6 {
+    font-size: 30px;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-top: 3rem;
+    margin-bottom: 8px;
+    color: #151515;
+}
+
+.error-page_p {
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 3rem;
+    margin-bottom: 3rem;
+    color: #151515;
+}
+
 @media screen and (max-width: 600px) {
     .column {
         width: 100%;

--- a/samples/asgardeo-react-app/src/error-boundary.tsx
+++ b/samples/asgardeo-react-app/src/error-boundary.tsx
@@ -2,8 +2,8 @@ import { AsgardeoAuthException } from "@asgardeo/auth-react";
 import React, { FunctionComponent, ReactElement } from "react";
 import { AuthenticationFailure } from "./pages/AuthenticationFailure";
 import { InvalidSystemTimePage } from "./pages/InvalidSystemTime";
-import {IssuerClaimValidationFailure} from "./pages/IssuerClaimValidationFailuer";
-import {VerifyIDTokenFailure} from "./pages/VerifyIDTokenFailure";
+import { IssuerClaimValidationFailure } from "./pages/IssuerClaimValidationFailure";
+import { VerifyIDTokenFailure } from "./pages/VerifyIDTokenFailure";
 
 interface ErrorBoundaryProps {
   error: AsgardeoAuthException;

--- a/samples/asgardeo-react-app/src/error-boundary.tsx
+++ b/samples/asgardeo-react-app/src/error-boundary.tsx
@@ -2,6 +2,8 @@ import { AsgardeoAuthException } from "@asgardeo/auth-react";
 import React, { FunctionComponent, ReactElement } from "react";
 import { AuthenticationFailure } from "./pages/AuthenticationFailure";
 import { InvalidSystemTimePage } from "./pages/InvalidSystemTime";
+import {IssuerClaimValidationFailure} from "./pages/IssuerClaimValidationFailuer";
+import {VerifyIDTokenFailure} from "./pages/VerifyIDTokenFailure";
 
 interface ErrorBoundaryProps {
   error: AsgardeoAuthException;
@@ -13,8 +15,14 @@ export const ErrorBoundary: FunctionComponent<ErrorBoundaryProps> = (
 ): ReactElement => {
   const { error, children } = props;
 
-  if (error?.code === "SPA-CRYPTO-UTILS-VJ-IV01" || error?.message === "ERR_JWT_CLAIM_VALIDATION_FAILED nbf") {
-    return <InvalidSystemTimePage />
+  if (error?.code === "SPA-CRYPTO-UTILS-VJ-IV01") {
+    if (error?.message === "ERR_JWT_CLAIM_VALIDATION_FAILED nbf") {
+      return <InvalidSystemTimePage />
+    } else if (error?.message === "ERR_JWT_CLAIM_VALIDATION_FAILED iss") {
+      return <IssuerClaimValidationFailure/>
+    } else {
+      return <VerifyIDTokenFailure error={error}/>
+    }
   } else if (error?.code === "SPA-MAIN_THREAD_CLIENT-SI-SE01") {
     return <AuthenticationFailure />
   }

--- a/samples/asgardeo-react-app/src/pages/InvalidSystemTime.tsx
+++ b/samples/asgardeo-react-app/src/pages/InvalidSystemTime.tsx
@@ -30,23 +30,10 @@ export const InvalidSystemTimePage: FunctionComponent = (): ReactElement => {
 
   return (
     <DefaultLayout>
-      <h6 style={{
-          fontSize: "30px",
-          textTransform: "uppercase",
-          fontWeight: 600,
-          marginTop: "3rem",
-          marginBottom: "8px",
-          color: "#151515"
-        }}>
+      <h6 className="error-page_h6">
           Your Clock is Invalid !
       </h6>
-      <p style={{
-          fontSize: "20px",
-          fontWeight: 400,
-          marginTop: "3rem",
-          marginBottom: "3rem",
-          color: "#151515"
-        }}>
+      <p className="error-page_p">
           It looks like your computer&rsquo;s date and time is incorrect. Please validate and try again
       </p>
     </DefaultLayout>

--- a/samples/asgardeo-react-app/src/pages/IssuerClaimValidationFailuer.tsx
+++ b/samples/asgardeo-react-app/src/pages/IssuerClaimValidationFailuer.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, ReactElement } from "react";
+import { DefaultLayout } from "../layouts/default";
+
+/**
+ * Page to display for ID token claim validation failure.
+ *
+ * @return {React.ReactElement}
+ */
+export const IssuerClaimValidationFailure: FunctionComponent = (): ReactElement => {
+
+    return (
+        <DefaultLayout>
+            <h6 style={{
+                fontSize: "30px",
+                textTransform: "uppercase",
+                fontWeight: 600,
+                marginTop: "3rem",
+                marginBottom: "8px",
+                color: "#151515"
+            }}>
+                Issuer claim validation failed!
+            </h6>
+            <p style={{
+                fontSize: "20px",
+                fontWeight: 400,
+                marginTop: "3rem",
+                marginBottom: "3rem",
+                color: "#151515"
+            }}>
+                The configured BaseURL in config.json might be incorrect.Make sure to remove any
+                trailing spaces if present.
+            </p>
+        </DefaultLayout>
+    );
+};

--- a/samples/asgardeo-react-app/src/pages/IssuerClaimValidationFailure.tsx
+++ b/samples/asgardeo-react-app/src/pages/IssuerClaimValidationFailure.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,24 +28,11 @@ export const IssuerClaimValidationFailure: FunctionComponent = (): ReactElement 
 
     return (
         <DefaultLayout>
-            <h6 style={{
-                fontSize: "30px",
-                textTransform: "uppercase",
-                fontWeight: 600,
-                marginTop: "3rem",
-                marginBottom: "8px",
-                color: "#151515"
-            }}>
+            <h6 className="error-page_h6">
                 Issuer claim validation failed!
             </h6>
-            <p style={{
-                fontSize: "20px",
-                fontWeight: 400,
-                marginTop: "3rem",
-                marginBottom: "3rem",
-                color: "#151515"
-            }}>
-                The configured BaseURL in config.json might be incorrect.Make sure to remove any
+            <p className="error-page_p">
+                The configured BaseURL in config.json might be incorrect. Make sure to remove any
                 trailing spaces if present.
             </p>
         </DefaultLayout>

--- a/samples/asgardeo-react-app/src/pages/VerifyIDTokenFailure.tsx
+++ b/samples/asgardeo-react-app/src/pages/VerifyIDTokenFailure.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,11 @@
 
 import React, { FunctionComponent, ReactElement } from "react";
 import { DefaultLayout } from "../layouts/default";
-import {AsgardeoAuthException} from "@asgardeo/auth-react";
+import { AsgardeoAuthException } from "@asgardeo/auth-react";
+
+interface VerifyIDTokenFailureProps {
+    error?: AsgardeoAuthException;
+}
 
 /**
  * Page to display for ID token verifying failures Page.
@@ -27,42 +31,18 @@ import {AsgardeoAuthException} from "@asgardeo/auth-react";
  *
  * @return {React.ReactElement}
  */
-
-
-interface VerifyIDTokenFailureProps {
-    error?: AsgardeoAuthException;
-}
 export const VerifyIDTokenFailure: FunctionComponent<VerifyIDTokenFailureProps> =
     ({error}): ReactElement => {
 
     return (
         <DefaultLayout>
-            <h6 style={{
-                fontSize: "30px",
-                textTransform: "uppercase",
-                fontWeight: 600,
-                marginTop: "3rem",
-                marginBottom: "8px",
-                color: "#151515"
-            }}>
+            <h6 className="error-page_h6">
                 ID token validation failed!
             </h6>
-            <p style={{
-                fontSize: "20px",
-                fontWeight: 400,
-                marginTop: "3rem",
-                marginBottom: "3rem",
-                color: "#151515"
-            }}>
-                Issue occurred when verifying ID token.
+            <p className="error-page_p">
+                Issue occurred while verifying ID token.
             </p>
-            <p style={{
-                fontSize: "18px",
-                fontWeight: 400,
-                marginTop: "1rem",
-                marginBottom: "3rem",
-                color: "#151515"
-            }}>
+            <p className="error-page_p">
                 Error message : {error?.message}<br />
                 Error reason : {error?.name}
             </p>

--- a/samples/asgardeo-react-app/src/pages/VerifyIDTokenFailure.tsx
+++ b/samples/asgardeo-react-app/src/pages/VerifyIDTokenFailure.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, ReactElement } from "react";
+import { DefaultLayout } from "../layouts/default";
+import {AsgardeoAuthException} from "@asgardeo/auth-react";
+
+/**
+ * Page to display for ID token verifying failures Page.
+ *
+ * @param {VerifyIDTokenFailureProps} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+
+
+interface VerifyIDTokenFailureProps {
+    error?: AsgardeoAuthException;
+}
+export const VerifyIDTokenFailure: FunctionComponent<VerifyIDTokenFailureProps> =
+    ({error}): ReactElement => {
+
+    return (
+        <DefaultLayout>
+            <h6 style={{
+                fontSize: "30px",
+                textTransform: "uppercase",
+                fontWeight: 600,
+                marginTop: "3rem",
+                marginBottom: "8px",
+                color: "#151515"
+            }}>
+                ID token validation failed!
+            </h6>
+            <p style={{
+                fontSize: "20px",
+                fontWeight: 400,
+                marginTop: "3rem",
+                marginBottom: "3rem",
+                color: "#151515"
+            }}>
+                Issue occurred when verifying ID token.
+            </p>
+            <p style={{
+                fontSize: "18px",
+                fontWeight: 400,
+                marginTop: "1rem",
+                marginBottom: "3rem",
+                color: "#151515"
+            }}>
+                Error message : {error?.message}<br />
+                Error reason : {error?.name}
+            </p>
+        </DefaultLayout>
+    );
+};


### PR DESCRIPTION
## Purpose
> Add specific error pages for ID token validation failures. This will fix the https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/192

## Goals
> This fix adds a specific error page for issuer claim validation failure of the ID token. Furthermore a generic error page is implemented to handle ID token verification failures.

## Approach
> Issuer claim validation failure is implemented by adding a specific error page rendered according to the error code returned by the jose library when issuer claim validation is failed. Similarly the generic error page for ID token verification failures is also implemented by leveraging the error code returned by the jose library.







 
