### PR TITLE
Fix RPIframe incorrect response mode param

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -37,7 +37,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^3.0.0"
+        "@asgardeo/auth-spa": "^3.0.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
   resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-5.0.0.tgz#ad63c232ac0588363e95c54d576c6318a6d4be93"
   integrity sha512-BMQsTzpFwtgbSeJvmSDgRrOjXfA6+yQ2NUq7CXP4q1TtqZJt8s/zadOazPM00/jIY8B2ENS0CLRHp07M0mFdOw==
 
-"@asgardeo/auth-spa@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.0.tgz#5b852a34850a5f8a70c22725d0f283925905f8b6"
-  integrity sha512-97WU9e9rt2FtmZwWyDYriEb9u3ZbUGZ/jkdKnXwIwwZod5+8yJsZq+dxFrvl2Bu473RfvdWr/kvXx6/DfZWBKg==
+"@asgardeo/auth-spa@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.1.tgz#94237193446b48eecc9d6bd780ece1124cccdcd7"
+  integrity sha512-GJWDpNaU2GE6hkelc+B4fuKMJ6PwHEq0WsktZ8cjW/EKtqL6z7WU+ywDzQFMZRTBAdTofkY2qVms53I8hI8LOg==
   dependencies:
     "@asgardeo/auth-js" "^5.0.0"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
## Purpose

Response mode `query` is send with a wrong casing to the RPIframe's prompt=none `authorize` request.

<img width="915" alt="Screenshot 2024-01-18 at 12 05 35" src="https://github.com/asgardeo/asgardeo-auth-react-sdk/assets/25959096/7bd88429-57b2-4e65-9c43-de2b77004f77">

This was fixed in `@asgardeo/auth-spa` `v3.0.1`. (https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/162)

*Reason*

This seems to have been introduced with https://github.com/asgardeo/asgardeo-auth-spa-sdk/commit/8b77734ba93d80c4eac4c6bcce74ab93c81b5f93 change, and it was previously working fine due to the authparam transformation(https://github.com/asgardeo/asgardeo-auth-js-core/pull/203/files#diff-f34c1fc70c8dfe6982556af3ab69b70a42b7a68c9119cfa0bfa4716acd929750R120). This was removed with https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/208.

## Goals
- Fixes https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/210

## Approach

- Change `responseMode` to `response_mode`.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   - N/A
 - Integration tests
   - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
N/A

## Related PRs
- https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/162

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A