### PR TITLE
Support additional params in trySignInSilently URL and bump auth-spa

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -37,7 +37,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardeo/auth-spa": "^3.0.1"
+        "@asgardeo/auth-spa": "^3.0.2"
     },
     "devDependencies": {
         "@babel/cli": "^7.19.3",

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -410,10 +410,11 @@ class AuthAPI {
      */
     public async trySignInSilently(
         state: AuthStateInterface,
-        dispatch: (state: AuthStateInterface) => void
+        dispatch: (state: AuthStateInterface) => void,
+        additionalParams?: Record<string, string | boolean>
     ): Promise<BasicUserInfo | boolean | undefined> {
         return this._client
-            .trySignInSilently()
+            .trySignInSilently(additionalParams)
             .then(async (response: BasicUserInfo | boolean) => {
                 if (!response) {
                     this.updateState({ ...this.getState(), isLoading: false });

--- a/lib/src/authenticate.tsx
+++ b/lib/src/authenticate.tsx
@@ -131,7 +131,9 @@ const AuthProvider: FunctionComponent<PropsWithChildren<AuthProviderPropsInterfa
 
         return AuthClient.on(hook, callback);
     };
-    const trySignInSilently = () => AuthClient.trySignInSilently(state, dispatch);
+    const trySignInSilently = (
+        additionalParams?: Record<string, string | boolean>
+    ) => AuthClient.trySignInSilently(state, dispatch, additionalParams);
     
     const [ error, setError ] = useState<AsgardeoAuthException>();
     const reRenderCheckRef: MutableRefObject<boolean> = useRef(false);

--- a/lib/src/models.ts
+++ b/lib/src/models.ts
@@ -113,7 +113,7 @@ export interface AuthContextInterface {
     enableHttpHandler(): Promise<boolean>;
     disableHttpHandler(): Promise<boolean>;
     updateConfig(config: Partial<AuthClientConfig<Config>>): Promise<void>;
-    trySignInSilently: () => Promise<boolean | BasicUserInfo>;
+    trySignInSilently: (additionalParams?: Record<string, string | boolean>) => Promise<boolean | BasicUserInfo>;
     on(hook: Hooks.CustomGrant, callback: (response?: any) => void, id: string): void;
     on(
         hook: Exclude<Hooks, Hooks.CustomGrant>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
   resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-5.0.0.tgz#ad63c232ac0588363e95c54d576c6318a6d4be93"
   integrity sha512-BMQsTzpFwtgbSeJvmSDgRrOjXfA6+yQ2NUq7CXP4q1TtqZJt8s/zadOazPM00/jIY8B2ENS0CLRHp07M0mFdOw==
 
-"@asgardeo/auth-spa@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.1.tgz#94237193446b48eecc9d6bd780ece1124cccdcd7"
-  integrity sha512-GJWDpNaU2GE6hkelc+B4fuKMJ6PwHEq0WsktZ8cjW/EKtqL6z7WU+ywDzQFMZRTBAdTofkY2qVms53I8hI8LOg==
+"@asgardeo/auth-spa@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.2.tgz#1827067d36482ac142a48defa45fa82c785e81bc"
+  integrity sha512-z25jzo+vQAju0wIplsQmHfczd+SwWy/cFRt9Dlnv+3dhb7ofygTD5to4nuvDA9DtW775qHl7XHi5R2M5xChJaQ==
   dependencies:
     "@asgardeo/auth-js" "^5.0.0"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
## Purpose
$subject
Bump @asgardeo/auth-spa to `3.0.2`

**Related Issue**
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/218