### PR TITLE
Update lock file to include SPA SDK version bump

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
   resolved "https://registry.yarnpkg.com/@asgardeo/auth-js/-/auth-js-5.0.0.tgz#ad63c232ac0588363e95c54d576c6318a6d4be93"
   integrity sha512-BMQsTzpFwtgbSeJvmSDgRrOjXfA6+yQ2NUq7CXP4q1TtqZJt8s/zadOazPM00/jIY8B2ENS0CLRHp07M0mFdOw==
 
-"@asgardeo/auth-spa@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.2.tgz#1827067d36482ac142a48defa45fa82c785e81bc"
-  integrity sha512-z25jzo+vQAju0wIplsQmHfczd+SwWy/cFRt9Dlnv+3dhb7ofygTD5to4nuvDA9DtW775qHl7XHi5R2M5xChJaQ==
+"@asgardeo/auth-spa@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.0.3.tgz#0b02c4a86f10c38756f407cde9ca48616dbf2adc"
+  integrity sha512-2iRy6Si/xl68EsUV92IuMz0s9/8nFq/a+63Ui0Xr2Ysjc3YsWIO0zVmdpqevZ1J9yzGb9Fyy7uqlKE0QY7m8pA==
   dependencies:
     "@asgardeo/auth-js" "^5.0.0"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

SPA SDK version was updated recently using the Github UI, therefore the yarn.lock file does not include the latest spa sdk version. This is causing issues in the release workflows[1]

This PR is to fix this.

[1] https://github.com/asgardeo/asgardeo-auth-react-sdk/actions/runs/9043238412/job/24850815967