### PR TITLE
Remove outdated info on accessing decoded ID token response when storage is set to webWorker

### DIFF
--- a/API.md
+++ b/API.md
@@ -507,9 +507,6 @@ This method returns the `ID token` in a form of a string. To get the decoded ID 
 ```TypeScript
 getIDToken(): Promise<string>
 ```
->**Warning**
->The promise resolves successfully only if the storage type is set to [`sessionStorage`](#session-storage) or [`localStorage`](#local-storage). If it is set to [`webWorker`](#web-worker), an error is thrown.
->The reason is that the token is stored inside the web worker and cannot be accessed from outside.
 
 #### Returns
 A promise that resolves with the ID token as a string.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

React sdk returns the decoded ID token response, even when using webWorker as the storage mechanism, therefore the docs need to be updated.

