### PR TITLE
Fix TypeScript declaration file path for `@asgardeo/auth-react` module to resolve TS7016 error

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -15,7 +15,7 @@
         "React"
     ],
     "main": "dist/main.js",
-    "types": "dist/src/index.d.ts",
+    "types": "dist/types/src/index.d.ts",
     "module": "dist/main.js",
     "scripts": {
         "lint": "eslint --ext .js,.ts .",


### PR DESCRIPTION
## Purpose
I encountered a TypeScript error (TS7016) where it couldn't find a declaration file for the `@asgardeo/auth-react` module. This happened because the path to the type definition file was incorrect in the module's `package.json`.

## Goals
The goal was to fix the incorrect path in `package.json` so TypeScript could locate the correct type definition file and avoid assigning an implicit `any` type to the module.

## Approach
1. Initially, the `package.json` had this:
   ```json
   "types": "dist/src/index.d.ts"
   ```
2. I changed it to:
   ```json
   "types": "dist/types/src/index.d.ts"
   ```

This fixed the error by pointing to the correct type file.

## Learning
I used the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html) to understand how to configure the `types` field in `package.json`. It explained how TypeScript looks for type files when a module is imported, helping me identify and correct the issue.