### PR TITLE
Disable PR Builder for Bot Commits & Prevent Sample Apps from Publishing

### DIFF
--- a/.changeset/slow-berries-train.md
+++ b/.changeset/slow-berries-train.md
@@ -1,0 +1,6 @@
+---
+"@asgardeo/choreo-react-express": patch
+"@asgardeo/react-app": patch
+---
+
+Prevent publish samples to npm

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   build:
+    if: github.actor != 'github-actions[bot]'
 
     runs-on: ubuntu-latest
 

--- a/samples/asgardeo-choreo-react-express/apps/client/package.json
+++ b/samples/asgardeo-choreo-react-express/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "version": "1.1.18",
-  "private": false,
+  "private": true,
   "dependencies": {
     "@asgardeo/auth-react": "^1.1.18",
     "@testing-library/jest-dom": "^5.16.5",

--- a/samples/asgardeo-choreo-react-express/apps/server/package.json
+++ b/samples/asgardeo-choreo-react-express/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "server",
   "version": "1.1.18",
-  "private": false,
+  "private": true,
   "type": "module",
   "author": "Yathindra Kodithuwakku <yathindrarawya123@gmail.com>",
   "scripts": {

--- a/samples/asgardeo-react-app/package.json
+++ b/samples/asgardeo-react-app/package.json
@@ -27,7 +27,7 @@
     "homepage": "https://github.com/asgardeo/asgardeo-auth-react-sdk#readme",
     "author": "WSO2",
     "license": "Apache-2.0",
-    "private": false,
+    "private": true,
     "scripts": {
         "start": "webpack-dev-server --mode development --hot --open",
         "prebuild": "yarn install",


### PR DESCRIPTION
### Purpose
This PR introduce two changes, 
1. Stops triggering PR builder when Github Action Bot commits.
2. Prevents publishing sample apps to NPM  

### Reference
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/272

