### PR TITLE
Disable PR builder on Asgardeo Bot

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'asgardeo-github-bot'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Purpose
Earlier in https://github.com/asgardeo/asgardeo-auth-react-sdk/pull/279, we disabled PR builder on the github actions bot, however the PR builder was still being triggered as the PR was being authored by the Asgardeo bot.

This PR stops triggered PR builder for Asgardeo Bot.
### Related Issue
- https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/272




### Related PRs
- https://github.com/asgardeo/asgardeo-auth-react-sdk/pull/279