### PR TITLE
Remove redundant steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,32 +80,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ASGARDIO_GITHUB_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Pack Release Artifacts
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          mkdir artifacts
-          if test -d samples
-          then
-            cd samples
-            rm -rf **/node_modules/
-            rm -rf samples/**/dist/
-            rm -rf samples/asgardeo-choreo-react-express/apps/**/node_modules/
-            rm -rf samples/asgardeo-choreo-react-express/apps/client/build/
-            rm -rf samples/asgardeo-choreo-react-express/apps/server/dist/
-            for dir in */ ; do
-                zip -r "../artifacts/${dir%/}.zip" $dir
-            done
-          fi
-
-      - name: Release Asgardeo Auth React SDK
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          version=`git describe --tags --abbrev=0`
-          echo ${{secrets.ASGARDIO_GITHUB_BOT_TOKEN}} | gh auth login --with-token
-          if test -d samples
-          then
-            gh release create $version artifacts/*
-          else
-            gh release create $version
-          fi

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,52 +1,15 @@
 ## Purpose
-> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
+<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->
 
-## Goals
-> Describe the solutions that this feature/fix will introduce to resolve the problems described above
-
-## Approach
-> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.
-
-## User stories
-> Summary of user stories addressed by this change>
-
-## Release note
-> Brief description of the new feature or bug fix as it will appear in the release notes
-
-## Documentation
-> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact
-
-## Training
-> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable
-
-## Certification
-> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.
-
-## Marketing
-> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable
-
-## Automation tests
- - Unit tests 
-   > Code coverage information
- - Integration tests
-   > Details about the test cases and coverage
+## Related issues
 
 ## Security checks
- - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- - Ran FindSecurityBugs plugin and verified report? yes/no
- - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
+ - [] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
+ - [] Ran FindSecurityBugs plugin and verified report
+ - [] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
 
 ## Samples
-> Provide high-level details about the samples related to this feature
+<!-- Provide high-level details about the samples related to this feature -->
 
 ## Related PRs
-> List any other related PRs
-
-## Migrations (if applicable)
-> Describe migration steps and platforms on which migration has been tested
-
-## Test environment
-> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
- 
-## Learning
-> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
+<!-- List any other related PRs -->


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

With the introduction of changesets, we don't need to manually pack the release artifacts and do the github releases. This PR removes those redundant steps in the release workflow.

Plus, this PR updates the PR template by removing unnecessary fields.
