### PR TITLE
Update`@asgardeo/auth-spa` to `v3.2.0`

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -47,7 +47,7 @@
         "LICENSE"
     ],
     "dependencies": {
-        "@asgardeo/auth-spa": "^3.1.5"
+        "@asgardeo/auth-spa": "^3.2.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
   resolved "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-5.1.1.tgz"
   integrity sha512-yIgBKvHbt9ENczm2n3FGPET/Xf0I9H+Jm6oMXb8ClB/5m5qygHLoF3bsiDlzNuw3wuz8RH8F+waRudVI+IoLtQ==
 
-"@asgardeo/auth-spa@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/@asgardeo/auth-spa/-/auth-spa-3.1.5.tgz"
-  integrity sha512-LoQA96oFQ7wegN9RoeYrhUsdxDPGcC8ys6drA5XstrupsM1tQ1698Dsfx4Pt22AEpiw4JwWoITZpIEVJzd4FvA==
+"@asgardeo/auth-spa@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asgardeo/auth-spa/-/auth-spa-3.2.0.tgz#338f5cd1974a4bead81f9db7e950f480a3040214"
+  integrity sha512-ptNeWyccApqpMVi9t1RYI95d0/jCS1Zs7qh9uU2c9FbTIquv2xMbJZhUCmU9Ana3IC+ouS53amxcUGZSVrh58g==
   dependencies:
     "@asgardeo/auth-js" "^5.1.1"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

ATM, when using TypeScript, we can't pass the `storage` option as strings. We need to use the `Storage` enum or cast the string. This is not good DX.

## Related issues
- Fixes https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/292

## Security checks
 - [] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
 - [] Ran FindSecurityBugs plugin and verified report
 - [] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Samples
<!-- Provide high-level details about the samples related to this feature -->
N/A

## Related PRs
- https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/189
