### PR TITLE
chore(release): attach asgardeo-samples.zip to GitHub Releases

### DIFF
--- a/.github/workflows/attach-react-sample-zip.yml
+++ b/.github/workflows/attach-react-sample-zip.yml
@@ -23,16 +23,23 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Create asgardeo-react-app.zip
+      - name: Create samples zip file
         run: |
-          cd samples/asgardeo-react-app
-          zip -r ../../asgardeo-react-app.zip . \
+          mkdir -p /tmp/samples
+          
+          cp -r samples/asgardeo-react-app /tmp/samples/
+          cp -r samples/asgardeo-choreo-react-express /tmp/samples/
+
+          cd /tmp
+          zip -r asgardeo-samples.zip samples \
             -x "**/node_modules/**" "**/.git/**"
+
+          mv asgardeo-samples.zip $GITHUB_WORKSPACE/
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: asgardeo-react-app.zip
+          files: asgardeo-samples.zip
           tag_name: ${{ inputs.tag || github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/attach-react-sample-zip.yml
+++ b/.github/workflows/attach-react-sample-zip.yml
@@ -25,9 +25,9 @@ jobs:
 
       - name: Create asgardeo-react-app.zip
         run: |
-          cd samples
-          zip -r ../asgardeo-react-app.zip asgardeo-react-app \
-            -x "**/node_modules/**" "**/.git/**" "**/dist/**" "**/.next/**" "**/build/**"
+          cd samples/asgardeo-react-app
+          zip -r ../../asgardeo-react-app.zip . \
+            -x "**/node_modules/**" "**/.git/**"
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/attach-react-sample-zip.yml
+++ b/.github/workflows/attach-react-sample-zip.yml
@@ -1,0 +1,38 @@
+name: Attach React sample ZIP to release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to upload to (manual runs)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs: 
+  upload-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout at ref
+        uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Create asgardeo-react-app.zip
+        run: |
+          cd samples
+          zip -r ../asgardeo-react-app.zip asgardeo-react-app \
+            -x "**/node_modules/**" "**/.git/**" "**/dist/**" "**/.next/**" "**/build/**"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: asgardeo-react-app.zip
+          tag_name: ${{ inputs.tag || github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Relates to wso2/product-is#23852

Adds a release workflow that zips:
- samples/asgardeo-react-app
- samples/asgardeo-choreo-react-express
and uploads `asgardeo-samples.zip` to each GitHub Release, also supports manual `workflow_dispatch` with a `tag` for testing.